### PR TITLE
#68: env.h: include intrin.h when using MSVC++

### DIFF
--- a/lib/env.h
+++ b/lib/env.h
@@ -20,6 +20,11 @@
 #  define BASE64_LITTLE_ENDIAN 0
 #endif
 
+// MSVC++ needs intrin.h for _byteswap_uint64 (issue #68):
+#if BASE64_LITTLE_ENDIAN && defined(_MSC_VER)
+#  include <intrin.h>
+#endif
+
 // Endian conversion functions:
 #if BASE64_LITTLE_ENDIAN
 #  ifdef _MSC_VER


### PR DESCRIPTION
When compiling with MSVC++ on a little-endian machine, include intrin.h
before using `_byteswap_uint64`, or that macro will be left undefined
and assumed by the compiler to return an int (which is generally
32-bit).